### PR TITLE
added spriteset to Night Vision style

### DIFF
--- a/styles/night-vision.json
+++ b/styles/night-vision.json
@@ -21,6 +21,7 @@
       "url": "https://osm.tegola.io/capabilities/osm.json"
     }
   },
+  "sprite": "https://go-spatial.github.io/tegola-web-demo/spritesets/osm_tegola_spritesheet",
   "glyphs": "https://go-spatial.github.io/tegola-web-demo/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/styles/night-vision3d.json
+++ b/styles/night-vision3d.json
@@ -21,6 +21,7 @@
       "url": "https://osm.tegola.io/capabilities/osm.json"
     }
   },
+  "sprite": "https://go-spatial.github.io/tegola-web-demo/spritesets/osm_tegola_spritesheet",
   "glyphs": "https://go-spatial.github.io/tegola-web-demo/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
Adding the single spriteset in the previous PR worked as far as allowing smooth transitions between all the styles _except_ night vision. That's because Night Vision didn't reference any stylesheet. Having it reference the main spritesheet should now allow it to have a smooth transition as well.