### PR TITLE
add a park overlay

### DIFF
--- a/styles/hot-osm.json
+++ b/styles/hot-osm.json
@@ -312,6 +312,30 @@
         }
       }
     },
+	{
+      "id": "landuse_areas_park_overlay",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "landuse_areas",
+      "minzoom": 10,
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "property": "type",
+          "type": "categorical",
+          "default": "transparent",
+          "stops": [
+            [
+              "park",
+              "rgba(208, 220, 174, 1)"
+            ]
+          ]
+        }
+      }
+    },
     {
       "id": "landuse_areas_z7",
       "type": "fill",

--- a/styles/hot-osm3d.json
+++ b/styles/hot-osm3d.json
@@ -312,6 +312,30 @@
         }
       }
     },
+	{
+      "id": "landuse_areas_park_overlay",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "landuse_areas",
+      "minzoom": 10,
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "property": "type",
+          "type": "categorical",
+          "default": "transparent",
+          "stops": [
+            [
+              "park",
+              "rgba(208, 220, 174, 1)"
+            ]
+          ]
+        }
+      }
+    },
     {
       "id": "landuse_areas_z7",
       "type": "fill",


### PR DESCRIPTION
In some cases residential polygons were being drawn over park polygons. It should be the other way around. This fixes the issue.